### PR TITLE
allow private projects to skip out on warnings

### DIFF
--- a/fixpack.js
+++ b/fixpack.js
@@ -11,9 +11,11 @@ function checkMissing(pack) {
     required.forEach(function (key) {
         if (!pack[key]) throw new Error('package.json files must have a ' + key);
     });
-    warn.forEach(function (key) {
-        if (!pack[key]) console.log(('missing ' + key).yellow);
-    });
+    if (!pack["private"]) {
+        warn.forEach(function (key) {
+            if (!pack[key]) console.log(('missing ' + key).yellow);
+        });
+    }
 }
 
 function sortObjectKeysAlphabetically(object) {


### PR DESCRIPTION
Our team has many internal projects that will never see the light of day, if you will, let alone have a homepage, etc. We mark them with `private: true,` in our package.json files, as to never accidentally push them to npm.

If private is truthy, I skip those warnings.