### PR TITLE
Use line feed character for EOF newline

### DIFF
--- a/fixpack.js
+++ b/fixpack.js
@@ -52,7 +52,7 @@ module.exports = function (file, log) {
     });
 
     // write it out
-    fs.writeFileSync(file, JSON.stringify(out, null, 2) + os.EOL, {encoding: 'utf8'});
+    fs.writeFileSync(file, JSON.stringify(out, null, 2) + '\n', {encoding: 'utf8'});
 
     if (log) console.log('package.json'.bold + ' fixed'.green + '!');
 };


### PR DESCRIPTION
As far as I know, `JSON.stringify(json, null, 2)` uses LF character for line endings in every platforms. [Specification](http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.3) said:

> Let separator be the result of concatenating the comma character, the ***line feed character***, and indent.

So, fixpack should use line feed character for EOF newline.