### PR TITLE
Also sort keywords automatically

### DIFF
--- a/fixpack.js
+++ b/fixpack.js
@@ -24,6 +24,10 @@ function sortObjectKeysAlphabetically(object) {
     return sorted;
 }
 
+function sortKeywordsAlphabetically(object) {
+    return object.keywords.sort();
+}
+
 module.exports = function (file, log) {
     var out = {};
     var pack = ALCE.parse(fs.readFileSync(file, {encoding: 'utf8'}));
@@ -50,6 +54,11 @@ module.exports = function (file, log) {
     ['dependencies', 'devDependencies', 'jshintConfig', 'scripts'].forEach(function (key) {
         if (out[key]) out[key] = sortObjectKeysAlphabetically(out[key]);
     });
+
+    // sort keywords
+    if ('keywords' in out) {
+      sortKeywordsAlphabetically(out);
+    }
 
     // write it out
     fs.writeFileSync(file, JSON.stringify(out, null, 2) + os.EOL, {encoding: 'utf8'});


### PR DESCRIPTION
npmjs.com doesn't sort keywords as yet, but it does sort dependencies and dependents.

Now that I've started sorting them, well, you know how it is...

Merge or no merge, thanks for fixpack!