### PR TITLE
Sort pre/post command wisely

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It will re-write your package.json file as follows:
 - author fourth
 - all other keys in alphabetical order
 - dependencies and devDependencies sorted alphabetically
+- scripts also sorted alphabetically, but pre/post commands are sorted before/after their matched command
 - newline at the end of the file
 
 It will warn you if any of these are missing:

--- a/fixpack.js
+++ b/fixpack.js
@@ -38,6 +38,28 @@ function sortAlphabetically (object) {
   }
 }
 
+function sortScriptsAlphabetically (object) {
+  var pre = {}
+  var post = {}
+  var sorted = {}
+  Object.keys(object).filter(function (key) {
+    if (key.startsWith('pre')) {
+      pre[key.substring(3)] = object[key]
+      return false
+    }
+    if (key.startsWith('post')) {
+      post[key.substring(4)] = object[key]
+      return false
+    }
+    return true
+  }).sort().forEach(function (key) {
+    if (pre[key]) sorted['pre' + key] = pre[key]
+    sorted[key] = object[key]
+    if (post[key]) sorted['post' + key] = post[key]
+  })
+  return sorted
+}
+
 module.exports = function (file, config) {
   config = extend(defaultConfig, config || {})
   if (!fs.existsSync(file)) {
@@ -74,7 +96,10 @@ module.exports = function (file, config) {
 
   // sort some sub items alphabetically
   config.sortedSubItems.forEach(function (key) {
-    if (out[key]) out[key] = sortAlphabetically(out[key])
+    if (out[key]) {
+      var sorted = (key === 'scripts') ? sortScriptsAlphabetically(out[key]) : sortAlphabetically(out[key])
+      out[key] = sorted
+    }
   })
 
   // wipe version numbers


### PR DESCRIPTION
Currently, fixpack sorts scripts alphabetically. This means pre/post
commands are split from their matched command.

This commit places pre/post commands to before/after matched command. It
would help organizing npm scripts.

From:

``` json
{
  "scripts": {
    "foo": "echo foo",
    "prefoo": "echo prefoo",
    "postfoo": "echo postfoo",
    "bar": "echo bar",
    "prebar": "echo prebar",
    "postbar": "echo postbar"
  }
}
```

To:

``` json
{
  "scripts": {
    "prebar": "echo prebar",
    "bar": "echo bar",
    "postbar": "echo postbar",
    "prefoo": "echo prefoo",
    "foo": "echo foo",
    "postfoo": "echo postfoo"
  }
}
```

Instead of:

``` json
{
  "scripts": {
    "bar": "echo bar",
    "foo": "echo foo",
    "postbar": "echo postbar",
    "postfoo": "echo postfoo",
    "prebar": "echo prebar",
    "prefoo": "echo prefoo"
  }
}
```
