### PR TITLE
bump deps and devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/henrikjoreteg/fixpack/issues"
   },
   "dependencies": {
-    "alce": "1.0.0",
+    "alce": "^1.2.0",
     "colors": "*",
     "extend-object": "^1.0.0",
-    "rc": "^0.6.0"
+    "rc": "^1.1.6"
   },
   "devDependencies": {
-    "standard": "^3.2.1"
+    "standard": "^7.1.2"
   },
   "homepage": "https://github.com/henrikjoreteg/fixpack",
   "keywords": [


### PR DESCRIPTION
- bumped [alce](https://www.npmjs.com/package/alce), [rc](https://www.npmjs.com/package/rc), and [standard](https://www.npmjs.com/package/standard)
- skimmed their commit logs and release notes, and didn't notice any breaking changes
- `npm test` still passes
- `fixpack` still makes expected changes to sample package.json files
