### PR TITLE
make exact devDeps 1.2.3 versions less strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It will re-write your package.json file as follows:
 - author fourth
 - all other keys in alphabetical order
 - dependencies and devDependencies sorted alphabetically
+- versions devDependencies / peerDependencies made less strict (^1.2.3)
 - newline at the end of the file
 
 It will warn you if any of these are missing:

--- a/config.json
+++ b/config.json
@@ -2,6 +2,10 @@
   "files": [
     "package.json"
   ],
+  "inexactVersions": [
+    "devDependencies",
+    "peerDependencies"
+  ],
   "quiet": false,
   "required": [
     "name",

--- a/fixpack.js
+++ b/fixpack.js
@@ -7,6 +7,8 @@ require('colors')
 
 var defaultConfig = require('./config')
 
+var EXACT_SEMVER = /^\d+\.\d+\.\d+$/
+
 function checkMissing (pack, config) {
   var warnItems
   var required
@@ -85,6 +87,18 @@ module.exports = function (file, config) {
       if (depGroup) {
         for (var item in depGroup) {
           depGroup[item] = '*'
+        }
+      }
+    })
+  }
+
+  // make exact 1.2.3 versions into inexact ^1.2.3 instead
+  if (config.inexactVersions && config.inexactVersions.length) {
+    config.inexactVersions.forEach(function (key) {
+      const depGroup = out[key]
+      for (var item in depGroup) {
+        if (EXACT_SEMVER.test(depGroup[item])) {
+          depGroup[item] = '^' + depGroup[item]
         }
       }
     })


### PR DESCRIPTION
- loosely related to #13 
- now by default, adjusts versions found in devDependencies and peerDependencies
- any exact versions (e.g. 1.2.3) are made less strict (e.g. ^1.2.3)
- devDeps don't affect end users, and being slightly less strict with them seems like a decent compromise between developer convenience and version certainty / safety
- good practice to keep peerDeps synchronised with devDeps where appropriate, hence doing both
