### PR TITLE
fix: use platform-specific newline character

### DIFF
--- a/fixpack.js
+++ b/fixpack.js
@@ -3,6 +3,7 @@ var ALCE = require('alce')
 var extend = require('extend-object')
 var fs = require('fs')
 var path = require('path')
+var os = require('os')
 require('colors')
 
 var defaultConfig = require('./config')
@@ -91,7 +92,7 @@ module.exports = function (file, config) {
   }
 
   // write it out
-  outputString = JSON.stringify(out, null, 2) + '\n'
+  outputString = JSON.stringify(out, null, 2) + os.EOL
 
   if (outputString !== original) {
     fs.writeFileSync(file, outputString, {encoding: 'utf8'})


### PR DESCRIPTION
Windows machines expect CRLF, Unix/Linux based systems expect LF. The `os.EOL` constant reflects that.

Currently, running `fixpack` on Windows and on a _package.json_ file with `CRLF` line endings results in a "fixed" _package.json_ due to the last newline (`CRLF`) being replaced with just `LF`.