### PR TITLE
Preserve or configure Indentation, newline and finalNewLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ The available options and their defaults shown below:
     wipe: false,
     // Sets the expected indentation. If number, is number of spaces,
     // otherwise can be string to use as indentation (like a tab).
-    // if undefined (default), indentation is detected from file and preserved.
-    indent: 2,
+    // if undefined/null (default), indentation is detected from file and preserved.
+    indent: null,
     // Sets line endings to be either "LF" or "CRLF"
-    // if undefined (default), newLine is detected from file and preserved.
-    newLine: "LF",
+    // if undefined/null (default), newLine is detected from file and preserved.
+    newLine: null,
     // Boolean if there should be an empty line at the end of the file.
-    // if undefined (default), finalNewLine is detected from file and preserved.
-    finalNewLine: true
+    // if undefined/null (default), finalNewLine is detected from file and preserved.
+    finalNewLine: null
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ It will warn you if any of these are missing:
 - homepage
 - license'
 
-Fix all indenting to 2 spaces.
+Maintain current indentation, End of Line, and Final New Line, or set them to your configured value
+(see [configuration](#configuration)).
 
 Oh, and it will tolerate improperly quoted and comma'd JSON thanks to [ALCE](https://npmjs.org/package/alce).
 
@@ -102,7 +103,17 @@ The available options and their defaults shown below:
     // this may be useful because then you can
     // run npm update --save && npm update --save-dev
     // to install latest stable releases of everything.
-    wipe: false
+    wipe: false,
+    // Sets the expected indentation. If number, is number of spaces,
+    // otherwise can be string to use as indentation (like a tab).
+    // if undefined (default), indentation is detected from file and preserved.
+    indent: 2,
+    // Sets line endings to be either "LF" or "CRLF"
+    // if undefined (default), newLine is detected from file and preserved.
+    newLine: "LF",
+    // Boolean if there should be an empty line at the end of the file.
+    // if undefined (default), finalNewLine is detected from file and preserved.
+    finalNewLine: true
 }
 
 ```

--- a/config.json
+++ b/config.json
@@ -39,5 +39,8 @@
     "description",
     "main"
   ],
-  "wipe": false
+  "wipe": false,
+  "indent": null,
+  "newLine": null,
+  "finalNewLine": null
 }

--- a/fixpack.js
+++ b/fixpack.js
@@ -57,9 +57,18 @@ module.exports = function(file, config) {
   }
   config.fileName = path.basename(file)
   const original = fs.readFileSync(file, { encoding: 'utf8' })
-  const indent = detectIndent(original).indent
-  const newLine = detectNewline(original)
-  const finalNewline = /\n$/.test(original)
+  const indent = config.indent != null
+    ? config.indent
+    : detectIndent(original).indent
+  const newLine = config.newLine != null
+    ? (
+      config.newLine === 'CRLF'
+        ? CRLF
+        : LF
+    ) : detectNewline(original) 
+  const finalNewLine = config.finalNewLine != null
+    ? !!config.finalNewLine
+    : /\n$/.test(original)
   const out = {}
   let pack = ALCE.parse(original)
   let outputString = ''
@@ -113,9 +122,9 @@ module.exports = function(file, config) {
   outputString = JSON.stringify(out, null, indent)
 
   if (newLine === CRLF) {
-    outputString = outputString.replace(/\n/g, CRLF) + (finalNewline ? CRLF : '')
+    outputString = outputString.replace(/\n/g, CRLF) + (finalNewLine ? CRLF : '')
   } else {
-    outputString = outputString + (finalNewline ? LF : '')
+    outputString = outputString + (finalNewLine ? LF : '')
   }
 
   if (outputString !== original) {

--- a/fixpack.js
+++ b/fixpack.js
@@ -2,7 +2,6 @@
 
 'use strict'
 
-const os = require('os')
 const ALCE = require('alce')
 const fs = require('fs')
 const path = require('path')

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,6 +270,16 @@
         }
       }
     },
+    "detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "alce": "1.0.0",
     "chalk": "^2.4.1",
+    "detect-indent": "^6.0.0",
+    "detect-newline": "^3.1.0",
     "extend-object": "^1.0.0",
     "rc": "^1.2.8"
   },


### PR DESCRIPTION
Make fixpack more flexible by, by default, preserving indenation (tabs vs num of spaces), newLine (CRLF vs LF) and if there should be a empty final line, and also allow configuration of all these if so wanted.

In my projects I use 4 spaces indentation, and everytime I run `fixpack` I need to remember to reformat the file to regain the 4 spaces indentation. Felt like it'd make sense to maintain indentation, and then when I was at it, I felt like there was also a risk of getting unwanted diffs if your file was using CRLF and/or not having the empty final line. 

Then I realise that some people surely want it to be strict and not adapt, so added configuration to set it explicitly.

Personally I feel like preserving from original file makes sense as a default, but if you want to, I could update the default configuration to maintain current behaviour (2 spaces, LF and add final newline).