### PR TITLE
Update dependencies and fix formatting

### DIFF
--- a/fixpack.js
+++ b/fixpack.js
@@ -14,7 +14,7 @@ const defaultConfig = require('./config')
 const CRLF = '\r\n';
 const LF = '\n';
 
-function checkMissing(pack, config) {
+function checkMissing (pack, config) {
   let warnItems
   let required
   if (pack.private) {
@@ -24,16 +24,15 @@ function checkMissing(pack, config) {
     warnItems = config.warn
     required = config.required
   }
-  required.forEach(function(key) {
-    if (pack[key] == null)
-      throw new Error(config.fileName + ' files must have a ' + key)
+  required.forEach(function (key) {
+    if (pack[key] == null) { throw new Error(config.fileName + ' files must have a ' + key) }
   })
-  warnItems.forEach(function(key) {
+  warnItems.forEach(function (key) {
     if (pack[key] == null && !config.quiet) console.log(chalk.yellow('missing ' + key))
   })
 }
 
-function sortAlphabetically(object) {
+function sortAlphabetically (object) {
   if (Array.isArray(object)) {
     object.sort()
     return object
@@ -41,14 +40,14 @@ function sortAlphabetically(object) {
     const sorted = {}
     Object.keys(object)
       .sort()
-      .forEach(function(key) {
+      .forEach(function (key) {
         sorted[key] = object[key]
       })
     return sorted
   }
 }
 
-module.exports = function(file, config) {
+module.exports = function (file, config) {
   config = Object.assign(defaultConfig, config || {})
   if (!fs.existsSync(file)) {
     if (!config.quiet) console.log(chalk.red('No such file: ' + file))
@@ -77,7 +76,7 @@ module.exports = function(file, config) {
   checkMissing(pack, config)
 
   // handle the specific ones we want, then remove
-  config.sortToTop.forEach(function(key) {
+  config.sortToTop.forEach(function (key) {
     if (pack[key] != null) out[key] = pack[key]
     delete pack[key]
   })
@@ -95,7 +94,7 @@ module.exports = function(file, config) {
   if (typeof out.keywords === 'string') out.keywords = [out.keywords]
 
   // sort some sub items alphabetically
-  config.sortedSubItems.forEach(function(key) {
+  config.sortedSubItems.forEach(function (key) {
     if (out[key] != null) out[key] = sortAlphabetically(out[key])
   })
 
@@ -107,7 +106,7 @@ module.exports = function(file, config) {
       'peerDependencies',
       'optionalDependencies'
     ]
-    versionedKeys.forEach(function(key) {
+    versionedKeys.forEach(function (key) {
       const depGroup = out[key]
       if (depGroup) {
         for (var item in depGroup) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@okunishinishi/fixpack",
+  "name": "fixpack",
   "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
@@ -22,7 +22,25 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "acorn": {
       "version": "7.1.0",
@@ -49,12 +67,12 @@
       }
     },
     "alce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/alce/-/alce-1.0.0.tgz",
-      "integrity": "sha1-QmGEyY7iiNDurHf9Y/7WgLZnyrY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/alce/-/alce-1.2.0.tgz",
+      "integrity": "sha1-qL4trKrEJJRhLxjcCdtpHz3qSqs=",
       "requires": {
-        "esprima": "~1.0.4",
-        "estraverse": "~1.3.0"
+        "esprima": "^1.2.0",
+        "estraverse": "^1.5.0"
       }
     },
     "ansi-escapes": {
@@ -127,21 +145,47 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -171,6 +215,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -178,7 +223,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -337,7 +383,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "6.4.0",
@@ -382,6 +429,19 @@
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "eslint-config-standard": {
@@ -621,9 +681,9 @@
       }
     },
     "esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+      "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
     },
     "esquery": {
       "version": "1.1.0",
@@ -660,9 +720,9 @@
       }
     },
     "estraverse": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-      "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
     },
     "esutils": {
       "version": "2.0.3",
@@ -825,7 +885,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -1798,6 +1859,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/henrikjoreteg/fixpack/issues"
   },
   "dependencies": {
-    "alce": "1.0.0",
-    "chalk": "^2.4.1",
+    "alce": "1.2.0",
+    "chalk": "^3.0.0",
     "detect-indent": "^6.0.0",
     "detect-newline": "^3.1.0",
     "extend-object": "^1.0.0",


### PR DESCRIPTION
Just a couple of small dependency updates (`alce` and `chalk`).

Also fixed the following formatting errors (in a separate commit):

```
fixpack.js:13:22: Missing space before function parentheses.
fixpack.js:23:28: Missing space before function parentheses.
fixpack.js:24:5: Expected { after 'if' condition.
fixpack.js:27:29: Missing space before function parentheses.
fixpack.js:32:28: Missing space before function parentheses.
fixpack.js:40:24: Missing space before function parentheses.
fixpack.js:47:26: Missing space before function parentheses.
fixpack.js:64:36: Missing space before function parentheses.
fixpack.js:82:41: Missing space before function parentheses.
fixpack.js:94:35: Missing space before function parentheses.
```
