### PR TITLE
Add "dryRun" flag and return non-zero exit code when file is not fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Oh, and it will tolerate improperly quoted and comma'd JSON thanks to [ALCE](htt
 
 Oh, and can do same if you pass it a `bower.json` file or whatnot.
 
+Oh, and it will exit with `0` when already fixed or with `1` otherwise (so combined with `--dryRun` flag it can be used as CI check)
+
 ## Usage
 
 1. install it globally
@@ -99,6 +101,8 @@ The available options and their defaults shown below:
     quiet: false,
     // files to scrub
     files: ['package.json'],
+    // Will not fix file, only inform if is fixed
+    dryRun: false,
     // Will set all deps to '*'
     // this may be useful because then you can
     // run npm update --save && npm update --save-dev

--- a/bin/fixpack
+++ b/bin/fixpack
@@ -11,6 +11,10 @@ if (files.length) {
   config.files = files
 }
 
+let exitCode = 0
+
 config.files.forEach(function (file) {
-  fixpack(path.resolve(file), config)
+  exitCode = Math.max(exitCode, fixpack(path.resolve(file), config))
 })
+
+process.exit(exitCode)

--- a/config.json
+++ b/config.json
@@ -39,6 +39,7 @@
     "description",
     "main"
   ],
+  "dryRun": false,
   "wipe": false,
   "indent": null,
   "newLine": null,

--- a/fixpack.js
+++ b/fixpack.js
@@ -51,7 +51,7 @@ module.exports = function (file, config) {
   config = Object.assign(defaultConfig, config || {})
   if (!fs.existsSync(file)) {
     if (!config.quiet) console.log(chalk.red('No such file: ' + file))
-    process.exit(1)
+    return 1
   }
   config.fileName = path.basename(file)
   const original = fs.readFileSync(file, { encoding: 'utf8' })
@@ -125,16 +125,16 @@ module.exports = function (file, config) {
     outputString = outputString + (finalNewLine ? LF : '')
   }
 
-  if (outputString !== original) {
-    fs.writeFileSync(file, outputString, { encoding: 'utf8' })
-    if (!config.quiet) {
-      console.log(chalk.bold(config.fileName) + chalk.green(' fixed') + '!')
-    }
-  } else {
-    if (!config.quiet) {
-      console.log(
-        chalk.bold(config.fileName) + chalk.green(' already clean') + '!'
-      )
-    }
+  if (outputString === original) {
+    config.quiet || console.log(chalk.bold(config.fileName) + chalk.green(' already clean') + '!')
+    return 0
   }
+
+  if (config.dryRun) {
+    config.quiet || console.log(chalk.bold(config.fileName) + chalk.red(' not fixed') + '!')
+  } else {
+    fs.writeFileSync(file, outputString, { encoding: 'utf8' })
+    config.quiet || console.log(chalk.bold(config.fileName) + chalk.green(' fixed') + '!')
+  }
+  return 1
 }


### PR DESCRIPTION
This PR:
 - adds returning exit code `1` if file is not fixed (and `0` if it already is)
 - adds `dryRun` flag so no changes are written

Motivation: with the `dryRun` it would be possible to run `fixpack --dryRun` in CI to make sure the file is fixed.